### PR TITLE
Implement responsive header with profile orbit

### DIFF
--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -1,0 +1,47 @@
+<script>
+  import ProfileWithOrbit from './ProfileWithOrbit.svelte';
+  import { onMount } from 'svelte';
+  export let initialShape = 'circle';
+  let isSmall = false;
+  let shape = initialShape;
+  const breakpoint = 768;
+  function updateHeaderSize() {
+    isSmall = window.innerWidth < breakpoint;
+    shape = isSmall ? 'pill' : 'circle';
+  }
+  onMount(() => {
+    updateHeaderSize();
+    window.addEventListener('resize', updateHeaderSize);
+    return () => window.removeEventListener('resize', updateHeaderSize);
+  });
+</script>
+
+<header class="site-header">
+  <ProfileWithOrbit shape={shape} />
+  <nav class="nav-links">
+    <a href="/" class="nav-link">Home</a>
+    <a href="/post_test" class="nav-link">Posts</a>
+    <a href="/projects" class="nav-link">Projects</a>
+  </nav>
+</header>
+
+<style>
+.site-header {
+  display: flex;
+  align-items: center;
+  padding: 1rem;
+  gap: 2rem;
+  transition: padding 0.3s ease;
+}
+.nav-links {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+@media (max-width: 768px) {
+  .site-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+</style>

--- a/src/components/Orbit.svelte
+++ b/src/components/Orbit.svelte
@@ -179,7 +179,9 @@
   });
 
   onDestroy(() => {
-    cancelAnimationFrame(frameId);
+    if (typeof cancelAnimationFrame !== 'undefined') {
+      cancelAnimationFrame(frameId);
+    }
   });
 </script>
 
@@ -188,5 +190,4 @@
     display: block;
   }
 </style>
-
 <canvas bind:this={canvas} style="display:block;"></canvas>

--- a/src/components/ProfileWithOrbit.svelte
+++ b/src/components/ProfileWithOrbit.svelte
@@ -1,76 +1,40 @@
 <script>
-  import { onMount } from 'svelte';
-  import OrbitCanvas from './Orbit.svelte';
-
-  export let src = '/me.JPG';
-  let size = 0;
-  export let profileSizeRatio = 1.4;
-
-  let wrapper;
-  let orbitRadius = 200; // Single radius value
-
-  const updateSize = () => {
-    size = orbitRadius * profileSizeRatio;
-  };
-
-  onMount(() => {
-    updateSize();
-  });
+  import Orbit from './Orbit.svelte';
+  export let shape = 'circle';
 </script>
 
-<style>
-  .wrapper {
-    --pill-shape: polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%);
-    --circle: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);
-    position: absolute;
-    top: -90px;
-    left: -90px;
-    pointer-events: none;
-    overflow: visible;
-  }
-  
-  .orbit-canvas {
-    position: absolute;
-    top: 0;
-    left: 0;
-  }
-  
-  .profile {
-    position: absolute;
-    border-radius: 50%;
-    overflow: hidden;
-    z-index: 2;
-    pointer-events: auto;
-    margin: 0;
-    padding: 0;
-    width: var(--size)px;
-    height: var(--size)px;
-    /* Center the profile within the orbit */
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-  }
-  
-  .profile img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    object-position: center;
-  }
-</style>
-
-<div 
-  class="wrapper" 
-  bind:this={wrapper}
->
-  <div class="orbit-canvas">
-    <OrbitCanvas radius={orbitRadius} />
-    <div class="profile">
-      <img {src} alt="Profile"/>
-    </div>
-  </div>
+<div class={`profile-container ${shape}`}>
+  <img src="/me.JPG" alt="Profile" class="profile-image" />
+  <Orbit class="orbit-canvas" radius={100} />
 </div>
 
-<svelte:window on:resize={updateSize} />
-
-
+<style>
+.profile-container {
+  position: relative;
+  transition: border-radius 0.4s ease, width 0.4s ease, height 0.4s ease;
+}
+.profile-container.circle {
+  width: 200px;
+  height: 200px;
+  border-radius: 50%;
+}
+.profile-container.pill {
+  width: 300px;
+  height: 150px;
+  border-radius: 100px;
+}
+.profile-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: inherit;
+}
+.orbit-canvas {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+</style>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,7 +1,8 @@
 ---
-import "../styles/global.css"; 
-import ProfileWithOrbit from '../components/ProfileWithOrbit.svelte';
-const { title } = Astro.props;
+import "../styles/global.css";
+import Header from '../components/Header.svelte';
+import ClientRouter from 'astro/components/ClientRouter.astro';
+const { title, headerShape = 'circle' } = Astro.props;
 ---
 
 <html lang="en">
@@ -9,22 +10,11 @@ const { title } = Astro.props;
     <meta charset="UTF-8" />
     <title>{title ? `Josh Prier - ${title}` : "Josh Prier"}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <ClientRouter />
   </head>
   <body class="theme-default">
-    <header class="site-header">
-      <div class="profile-orbit-container">
-        <ProfileWithOrbit client:only />
-      </div>
-      <nav class="site-nav">
-        <a href="/" class="nav-link">Home</a>
-        <a href="/about" class="nav-link">About</a>
-        <a href="/projects" class="nav-link">Projects</a>
-        <a href="/contact" class="nav-link">Contact</a>
-      </nav>
-    </header>
-
+    <Header client:load transition:persist transition:name="header" initialShape={headerShape} />
     <main>
       <slot />
     </main>
-  </body>
-</html>
+  </body></html>


### PR DESCRIPTION
## Summary
- create `Header.svelte` with responsive layout logic
- support morphing shape in `ProfileWithOrbit.svelte`
- add `ClientRouter` and header persistence in `BaseLayout`
- guard request animation frame cleanup for SSR

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686dbd8a449c832da6473149c606426b